### PR TITLE
Added Xenial support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,9 @@ class boost::params {
             'trusty': {
               $version = '1.54'
             }
+            'xenial': {
+              $version = '1.58'
+            }
             default: {
               fail("Unsupported Ubuntu release: ${::lsbdistcodename}")
             }


### PR DESCRIPTION
When running under xenial I got: 
```shell
 Unsupported Ubuntu release: xenial at /etc/puppet/modules/boost/manifests/params.pp:46
```
Thus added version `1.58` for xenial as found here https://packages.ubuntu.com/nl/source/xenial/boost1.58

